### PR TITLE
[BUGFIX] Respect cache clears via multi-tag cache clearing function

### DIFF
--- a/Classes/Cache/Backend/ReverseProxyCacheBackend.php
+++ b/Classes/Cache/Backend/ReverseProxyCacheBackend.php
@@ -130,6 +130,30 @@ class ReverseProxyCacheBackend extends Typo3DatabaseBackend
     }
 
     /**
+     * Removes all entries tagged by any of the specified tags.
+     *
+     * @param string[] $tags
+     */
+    public function flushByTags(array $tags)
+    {
+        $identifiers = [];
+        foreach($tags as $tag) {
+            $identifiers = array_merge($identifiers, $this->findIdentifiersByTag($tag));
+        }
+        $identifiers = array_unique($identifiers);
+
+        $urls = [];
+        foreach($identifiers as $entryIdentifier) {
+            $urls[] = $this->get($entryIdentifier);
+        }
+        $urls = array_unique($urls);
+
+        $this->reverseProxyProvider->flushCacheForUrls($urls);
+
+        parent::flushByTags($tags);
+    }
+
+    /**
      * Fetch all URLs in the cache.
      */
     public function getAllCachedUrls()

--- a/Classes/Provider/CurlHttpProxyProvider.php
+++ b/Classes/Provider/CurlHttpProxyProvider.php
@@ -66,11 +66,18 @@ class CurlHttpProxyProvider implements ProxyProviderInterface, SingletonInterfac
     /**
      * {@inheritdoc}
      */
-    public function flushAllUrls($urls = [])
+    public function flushCacheForUrls($urls = [])
     {
-        // SQL query to fetch all URLs
         $this->queue = $urls;
         $this->executeCacheFlush();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function flushAllUrls($urls = [])
+    {
+        $this->flushCacheForUrls($urls);
     }
 
     /**

--- a/Classes/Provider/FastlyProxyProvider.php
+++ b/Classes/Provider/FastlyProxyProvider.php
@@ -46,6 +46,16 @@ class FastlyProxyProvider implements ProxyProviderInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function flushCacheForUrls(array $urls)
+    {
+        foreach ($urls as $url) {
+            $this->flushCacheForUrl($url);
+        }
+    }
+
+    /**
      * Flushes the whole proxy cache.
      *
      * @param array $urls

--- a/Classes/Provider/ProxyProviderInterface.php
+++ b/Classes/Provider/ProxyProviderInterface.php
@@ -37,6 +37,13 @@ interface ProxyProviderInterface
     public function flushCacheForUrl($url);
 
     /**
+     * Flushes multiple urls from the proxy cache
+     *
+     * @param array $urls
+     */
+    public function flushCacheForUrls(array $urls);
+
+    /**
      * Flushes the whole proxy cache.
      *
      * @param array $urls


### PR DESCRIPTION
Override the flushByTags method offered by the Typo3DatabaseBackend,
so the reverse proxy does not miss cache clears run via this method.
Add a new flushCacheForUrls method to the Provider interface, so
API providers may clear multiple caches at once.