### PR TITLE
[TASK] Flash proxy caches on direct backend access

### DIFF
--- a/Classes/Cache/Backend/ReverseProxyCacheBackend.php
+++ b/Classes/Cache/Backend/ReverseProxyCacheBackend.php
@@ -80,9 +80,6 @@ class ReverseProxyCacheBackend extends Typo3DatabaseBackend
      */
     public function remove($entryIdentifier)
     {
-        if (!$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyIP']) {
-             return;
-        }
         // call the provider to forget this URL
         $url = $this->get($entryIdentifier);
         if ($url) {
@@ -98,9 +95,6 @@ class ReverseProxyCacheBackend extends Typo3DatabaseBackend
      */
     public function flush()
     {
-        if (!$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyIP']) {
-             return;
-        }
         $urls = $this->getAllCachedUrls();
         parent::flush();
 
@@ -115,9 +109,6 @@ class ReverseProxyCacheBackend extends Typo3DatabaseBackend
      */
     public function flushByTag($tag)
     {
-        if (!$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyIP']) {
-             return;
-        }
         $identifiers = $this->findIdentifiersByTag($tag);
         foreach ($identifiers as $entryIdentifier) {
             $url = $this->get($entryIdentifier);


### PR DESCRIPTION
Flash the caches of the reverse proxy or CDN, even if the backend
editor has direct (non reverse proxied) access to the origin server.